### PR TITLE
remove hard dependency on icpc in mapreduce sample

### DIFF
--- a/samples/count_all_words/mapreduce/Makefile
+++ b/samples/count_all_words/mapreduce/Makefile
@@ -13,7 +13,7 @@ endif
 
 APPNAME = mapreduce
 
-CXX = icpc
+#CXX = icpc
 TARGETS   := $(APPNAME) dist$(APPNAME)
 DEST_OBJS := $(TARGETS:=.o)
 CNCFILE   := $(APPNAME).cnc


### PR DESCRIPTION
- compilation works fine with g++ as well
